### PR TITLE
Paginate assignments and improve its looks

### DIFF
--- a/app/controllers/field_service/campaign_assignments_controller.rb
+++ b/app/controllers/field_service/campaign_assignments_controller.rb
@@ -28,7 +28,7 @@ class FieldService::CampaignAssignmentsController < ApplicationController
   private
 
   def attributes
-    params.require(:db_preaching_campaign_assignment)
+    params.require(:assignment)
       .permit(:assignee_id, :assigned_at, :returned_at)
   end
 

--- a/app/controllers/field_service/campaign_assignments_controller.rb
+++ b/app/controllers/field_service/campaign_assignments_controller.rb
@@ -2,7 +2,7 @@
 
 class FieldService::CampaignAssignmentsController < ApplicationController
   def index
-    campaign
+    @assignments = paginate(campaign.assignments.with_dependencies)
   end
 
   def edit

--- a/app/models/db/preaching_campaign_assignment.rb
+++ b/app/models/db/preaching_campaign_assignment.rb
@@ -5,5 +5,5 @@ class Db::PreachingCampaignAssignment < ApplicationRecord
   belongs_to :territory
   belongs_to :assignee, class_name: 'Publisher', optional: true
 
-  scope :with_dependencies, -> { includes(:territory, :assignee) }
+  scope :with_dependencies, -> { includes(:territory, :assignee).order('territories.name') }
 end

--- a/app/models/db/preaching_campaign_assignment.rb
+++ b/app/models/db/preaching_campaign_assignment.rb
@@ -4,4 +4,6 @@ class Db::PreachingCampaignAssignment < ApplicationRecord
   belongs_to :campaign, class_name: 'PreachingCampaign'
   belongs_to :territory
   belongs_to :assignee, class_name: 'Publisher', optional: true
+
+  scope :with_dependencies, -> { includes(:territory, :assignee) }
 end

--- a/app/views/field_service/campaign_assignments/edit.html.erb
+++ b/app/views/field_service/campaign_assignments/edit.html.erb
@@ -4,7 +4,7 @@
 <h2 class="mt-3"><%= model_name(model) %></h2>
 
 <div class="inline-check-boxes special-legends soft-labels">
-  <%= simple_form_for(@assignment, url: field_service_campaign_assignment_path(@campaign, @assignment)) do |f| %>
+  <%= simple_form_for(@assignment, url: field_service_campaign_assignment_path(@campaign, @assignment), as: :assignment) do |f| %>
     <div class="mb-3">
       <%= f.error_notification %>
     </div>

--- a/app/views/field_service/campaign_assignments/index.html.erb
+++ b/app/views/field_service/campaign_assignments/index.html.erb
@@ -14,7 +14,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @campaign.each_assignment do |assignemnt| %>
+    <% @assignments.each do |assignemnt| %>
       <tr>
         <td><%= assignemnt.territory.name %></td>
         <td><%= assignemnt.assignee&.name %></td>
@@ -31,3 +31,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= render PaginationComponent.new(@assignments)  %>

--- a/app/views/field_service/campaign_assignments/index.html.erb
+++ b/app/views/field_service/campaign_assignments/index.html.erb
@@ -16,7 +16,7 @@
   <tbody>
     <% @assignments.each do |assignemnt| %>
       <tr>
-        <td><%= assignemnt.territory.name %></td>
+        <td><%= render Territories::TerritoryNameComponent.new(assignemnt.territory, attribute_name: :name) %></td>
         <td><%= assignemnt.assignee&.name %></td>
         <td><%= assignemnt.assigned_at %></td>
         <td><%= assignemnt.returned_at %></td>

--- a/app/views/field_service/campaign_assignments/index.html.erb
+++ b/app/views/field_service/campaign_assignments/index.html.erb
@@ -2,34 +2,22 @@
 
 <%= render partial: 'campaign', locals: { buttons: true } %>
 
-<h2><%= model_name(model) %></h2>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th scope="col"><%= attribute_name(:territory, model: model) %></th>
-      <th scope="col"><%= attribute_name(:assignee, model: model) %></th>
-      <th scope="col"><%= attribute_name(:assigned_at, model: model) %></th>
-      <th scope="col"><%= attribute_name(:returned_at, model: model) %></th>
-      <th scope="col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @assignments.each do |assignemnt| %>
-      <tr>
-        <td><%= render Territories::TerritoryNameComponent.new(assignemnt.territory, attribute_name: :name) %></td>
-        <td><%= assignemnt.assignee&.name %></td>
-        <td><%= assignemnt.assigned_at %></td>
-        <td><%= assignemnt.returned_at %></td>
-        <td class="pull-right">
-          <%= render DropdownMenuComponent.new do |component| %>
-            <% component.item do %>
-              <%= link_to(t('app.links.edit'), edit_field_service_campaign_assignment_path(@campaign, assignemnt)) %>
-            <% end %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<h2 class="mt-3"><%= model_name(model) %></h2>
+<div class="index-list">
+  <% @assignments.each do |assignemnt| %>
+    <div class="item position-relative">
+      <%= render DropdownMenuComponent.new(type: :item_options) do |component| %>
+        <% component.item do %>
+          <%= link_to(t('app.links.edit'), edit_field_service_campaign_assignment_path(@campaign, assignemnt)) %>
+        <% end %>
+      <% end %>
+      <div class="row">
+        <%= render Territories::TerritoryNameComponent.new(assignemnt.territory, attribute_name: :name).wrap_with(:div, class: 'col-sm-12') %>
+        <%= render Territories::TerritoryAssigneeComponent.new(assignemnt, attribute_name: :assignee).wrap_with(:div, class: 'col-sm-6') %>
+        <%= render Territories::TerritoryAssignmentDatesComponent.new(assignemnt, attribute_name: :assignment_dates).wrap_with(:div, class: 'col-sm-6') %>
+      </div>
+    </div>
+  <% end %>
+</div>
 
 <%= render PaginationComponent.new(@assignments)  %>

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -93,6 +93,7 @@ pt-BR:
         territories: Territórios
         assignments: Designações
       db/preaching_campaign_assignment:
+        assignment_dates: Data designação
         campaign: Campanha
         territory: Território
         assignee: Designado para

--- a/spec/requests/field_service/campaign_assignments_request_spec.rb
+++ b/spec/requests/field_service/campaign_assignments_request_spec.rb
@@ -2,10 +2,13 @@
 
 require 'rails_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers:
 RSpec.describe 'FieldService::CampaignAssignments', type: :request do
   let(:described_class) { FieldService::CampaignAssignmentsController }
   let(:campaign) { assignment.campaign }
   let(:assignment) { factories.preaching_campaign_assignments.create }
+  let(:publisher) { factories.publishers.create }
+  let(:another_publisher) { factories.publishers.create }
 
   before do
     login_user(admin_user)
@@ -38,4 +41,26 @@ RSpec.describe 'FieldService::CampaignAssignments', type: :request do
       expect(response).to redirect_to(field_service_campaign_assignments_url(campaign))
     end
   end
+
+  describe 'PATCH #update' do
+    let(:perform_request) do
+      patch field_service_campaign_assignment_path(campaign, assignment),
+            params: { assignment: { assignee_id: another_publisher.id } }
+    end
+
+    it 'updates assignemnt' do
+      publisher
+
+      expect do
+        perform_request
+      end.to change { assignment.reload.assignee_id }.to(another_publisher.id)
+    end
+
+    it 'redirects to index page' do
+      perform_request
+
+      expect(response).to redirect_to(field_service_campaign_assignments_url(campaign))
+    end
+  end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers:


### PR DESCRIPTION
Fix #179

- Paginate campaign assignments
- Change assignment key
- Sort assignments by territory name
- Improve look of assignment index
