### PR TITLE
Add optional notes and campaign to territory assignments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,5 +27,10 @@ namespace :data do
     task(territory_assignments: :environment) do
       TerritoryAssignmentMigration.new.migrate
     end
+
+    desc "Migrate preching campaign assignments to territory assignments"
+    task(preaching_campaign_assignments_to_territory_assignments: :environment) do
+      PreachingCampaignAssignmentsToTerritoryAssignmentsMigration.new.migrate
+    end
   end
 end

--- a/app/components/territories/assignment_component.html.erb
+++ b/app/components/territories/assignment_component.html.erb
@@ -3,14 +3,20 @@
     <% if territory_perspective? %>
       <%= render attribute(assignment.assignee&.name)
         .with_label(:publisher)
-        .with_link(urls.publisher_path(assignment.assignee)).wrap_with(:div, class: 'col-md-6') %>
+        .with_link(urls.publisher_path(assignment.assignee)).wrap_with(:div, class: 'col-md-4') %>
     <% end %>
 
     <% if publisher_perspective? %>
       <%= render attribute(assignment.territory&.name)
         .with_label(:territory)
-        .with_link(urls.to(assignment.territory)).wrap_with(:div, class: 'col-md-6') %>
+        .with_link(urls.to(assignment.territory)).wrap_with(:div, class: 'col-md-4') %>
     <% end %>
+
+    <%= render attribute(assignment.campaign&.name)
+      .with_label(:campaign)
+      .with_link(campaign_url).wrap_with(:div, class: 'col-md-4') %>
+
+    <%= render attribute(assignment.notes).with_label(:notes) .wrap_with(:div, class: 'col-md-12') %>
 
     <%= render Territories::TerritoryAssignmentDatesComponent.new(assignment, attribute_name: :assignment_dates)
     .with_label(:assignment_dates)

--- a/app/components/territories/assignment_component.rb
+++ b/app/components/territories/assignment_component.rb
@@ -12,5 +12,11 @@ module Territories
     def publisher_perspective?
       parent.is_a?(Db::Publisher)
     end
+
+    def campaign_url
+      if assignment.campaign
+        urls.to(assignment.campaign)
+      end
+    end
   end
 end

--- a/app/components/territories/assignments/new_page_component.html.erb
+++ b/app/components/territories/assignments/new_page_component.html.erb
@@ -4,8 +4,17 @@
 
 <%= simple_form_for(:assignment, url: target_url) do |f| %>
   <%= input_wrapper do %>
-    <%= f.input :publisher_id, as: :select, collection: publishers, label: attribute_name(territory, :assignee_id) %>
+    <%= f.input :publisher_id, as: :select, collection: publishers, label: attribute_name(territory_assignment, :assignee_id) %>
   <% end %>
+
+  <%= input_wrapper do %>
+    <%= f.input :campaign_id, as: :select, collection: preaching_campaigns, label: attribute_name(territory_assignment, :campaign_id) %>
+  <% end %>
+
+  <%= input_wrapper do %>
+    <%= f.input :notes, label: attribute_name(territory_assignment, :notes) %>
+  <% end %>
+
   <%= input_wrapper do %>
     <%= f.submit(class: 'btn btn-primary mt-3 float-right', value: t('app.links.assign_territory')) %>
   <% end %>

--- a/app/components/territories/assignments/new_page_component.rb
+++ b/app/components/territories/assignments/new_page_component.rb
@@ -8,8 +8,16 @@ class Territories::Assignments::NewPageComponent < PageComponent
     Db::Publisher.all.pluck(:name, :id)
   end
 
+  def preaching_campaigns
+    Db::PreachingCampaign.order(created_at: :desc).pluck(:name, :id)
+  end
+
   def target_url
     urls.territory_assignments_path(territory)
+  end
+
+  def territory_assignment
+    @territory_assignment ||= territory.assignments.build
   end
 
   private

--- a/app/controllers/territories/assignments_controller.rb
+++ b/app/controllers/territories/assignments_controller.rb
@@ -4,7 +4,8 @@ class Territories::AssignmentsController < ApplicationController
   def create
     publisher_id = params[:assignment][:publisher_id]
     campaign_id = params[:assignment][:campaign_id]
-    territory.assign_to(publisher_id, campaign_id: campaign_id)
+    notes = params[:assignment][:notes]
+    territory.assign_to(publisher_id, campaign_id: campaign_id, notes: notes)
     show_territory
   end
 

--- a/app/controllers/territories/assignments_controller.rb
+++ b/app/controllers/territories/assignments_controller.rb
@@ -2,7 +2,9 @@
 
 class Territories::AssignmentsController < ApplicationController
   def create
-    territory.assign_to(params[:assignment][:publisher_id])
+    publisher_id = params[:assignment][:publisher_id]
+    campaign_id = params[:assignment][:campaign_id]
+    territory.assign_to(publisher_id, campaign_id: campaign_id)
     show_territory
   end
 

--- a/app/data_migrations/preaching_campaign_assignments_to_territory_assignments_migration.rb
+++ b/app/data_migrations/preaching_campaign_assignments_to_territory_assignments_migration.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# rubocop diasable: Rails/Output
+class PreachingCampaignAssignmentsToTerritoryAssignmentsMigration
+  def migrate
+    Db::PreachingCampaignAssignment.transaction do
+      assignments.find_each do |assignment|
+        convert(assignment)
+      end
+    end
+  end
+
+  private
+
+  def assignments
+    Db::PreachingCampaignAssignment.where.not(assignee_id: nil).order(assigned_at: :asc)
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+  def convert(assignment)
+    ta = Db::TerritoryAssignment.create!(
+      territory_id: assignment.territory_id,
+      campaign_id: assignment.campaign_id,
+      assignee_id: assignment.assignee_id,
+      assigned_at: assignment.assigned_at,
+      returned_at: assignment.returned_at
+    )
+
+    territory = ta.territory
+
+    if overwrite_assignment?(territory, ta)
+      if ta.returned_at
+        territory.assignee_id = nil
+        territory.assigned_at = nil
+      else
+        territory.assignee_id = ta.assignee_id
+        territory.assigned_at = ta.assigned_at
+      end
+    end
+
+    territory.save!
+  rescue ActiveRecord::RecordInvalid => exception
+    raise "#{exception.record.class} has errors: #{exception.record.errors.to_h}"
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+
+  def overwrite_assignment?(territory, assignment)
+    last_territory_movement = territory.assigned_at
+    last_assignment_movement = assignment.returned_at || assignment.assigned_at
+
+    unless last_territory_movement
+      return true
+    end
+
+    if last_territory_movement < last_assignment_movement
+      return true
+    end
+
+    false
+  end
+end

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -124,7 +124,7 @@ class Db::Territory < ApplicationRecord
   end
 
   # rubocop:disable Metrics/MethodLength
-  def assign_to(publisher)
+  def assign_to(publisher, campaign_id: nil)
     if assigned?
       raise AssignmentError, 'Already assigned'
     end

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -124,7 +124,8 @@ class Db::Territory < ApplicationRecord
   end
 
   # rubocop:disable Metrics/MethodLength
-  def assign_to(publisher, campaign_id: nil)
+  def assign_to(publisher, campaign_id: nil, notes: nil)
+    # TODO: allow multiple assignments for multiple campaigns
     if assigned?
       raise AssignmentError, 'Already assigned'
     end
@@ -138,7 +139,12 @@ class Db::Territory < ApplicationRecord
 
     self.class.transaction do
       save!
-      assignments.create!(assignee_id: assignee_id, assigned_at: assigned_at)
+      assignments.create!(
+        assignee_id: assignee_id,
+        assigned_at: assigned_at,
+        campaign_id: campaign_id,
+        notes: notes
+      )
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -125,7 +125,6 @@ class Db::Territory < ApplicationRecord
 
   # rubocop:disable Metrics/MethodLength
   def assign_to(publisher, campaign_id: nil, notes: nil)
-    # TODO: allow multiple assignments for multiple campaigns
     if assigned?
       raise AssignmentError, 'Already assigned'
     end

--- a/app/models/db/territory_assignment.rb
+++ b/app/models/db/territory_assignment.rb
@@ -3,6 +3,7 @@
 class Db::TerritoryAssignment < ApplicationRecord
   belongs_to :territory
   belongs_to :assignee, class_name: 'Publisher'
+  belongs_to :campaign, class_name: 'PreachingCampaign', optional: true
 
   default_scope -> { order(assigned_at: :desc) }
   scope :with_dependencies, -> { includes(%i[assignee territory]) }

--- a/app/models/routes.rb
+++ b/app/models/routes.rb
@@ -44,6 +44,10 @@ class Routes
     @helpers.territories_territory_assignment_path(territory, 'unassign')
   end
 
+  def preaching_campaign_path(campaign)
+    @helpers.field_service_campaign_path(campaign)
+  end
+
   def new_field_service_campaign_path
     @helpers.new_field_service_campaign_path
   end
@@ -77,7 +81,7 @@ class Routes
       return territory_path(record)
     end
 
-    raise "Unrecognized path for #{record.class}"
+    raise "Unrecognized path for #{record.class}/#{key}"
   end
 end
 # rubocop:enable Style/MissingRespondToMissing

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -181,6 +181,10 @@ pt-BR:
         phone_provider_id: Operadora Telefônica
         numbers: Números
         download_as: "Baixar"
+      db/territory_assignment:
+        assignee_id: Publicador
+        campaign_id: Campanha
+        notes: Observações
   app:
     attributes:
       publisher: "Publicador"

--- a/db/migrate/20220430141419_add_campaign_id_to_territory_assignments.rb
+++ b/db/migrate/20220430141419_add_campaign_id_to_territory_assignments.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCampaignIdToTerritoryAssignments < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :territory_assignments, :campaign, null: true,
+                                                     foreign_key: { to_table: :preaching_campaigns }
+  end
+end

--- a/db/migrate/20220430143210_add_notes_to_territory_assignments.rb
+++ b/db/migrate/20220430143210_add_notes_to_territory_assignments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotesToTerritoryAssignments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :territory_assignments, :notes, :text
+  end
+end

--- a/spec/models/db/territory_spec.rb
+++ b/spec/models/db/territory_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe Db::Territory, type: :model do
     subject(:territory) { factory.create }
 
     let(:publisher) { factories.publishers.create }
+    let(:campaign) { factories.preaching_campaigns.create }
     let(:assign) { territory.assign_to(publisher) }
 
     it 'assigns publisher' do
@@ -195,6 +196,18 @@ RSpec.describe Db::Territory, type: :model do
       assign
 
       expect(Db::TerritoryAssignment.last.assignee_id).to eq(publisher.id)
+    end
+
+    it 'optinally adds notes to assignment' do
+      territory.assign_to(publisher, notes: 'foo')
+
+      expect(Db::TerritoryAssignment.last.notes).to eq('foo')
+    end
+
+    it 'optinally adds campaign_id to assignment' do
+      territory.assign_to(publisher, campaign_id: campaign.id)
+
+      expect(Db::TerritoryAssignment.last.campaign_id).to eq(campaign.id)
     end
 
     it 'creates an assignment with correct timestamp' do


### PR DESCRIPTION
Close #248

- [x] Add campaign_id: keyword arg to Db::Territory#assign_to
- [x] Add preaching_campaign_id and notes to territory_assignments
- [x] Add campaign_id and notes to territory assignments form
- [x] Add optional campaign and notes during assignment
- [ ] Add edit button for campaign assignment to allow editing notes and campaign
- [ ] Add delete button for campaign assignment
- [ ] Add rake task to migrate data from preaching campaign assignments to regular campaigns