### PR TITLE
Scope territories to account

### DIFF
--- a/app/components/territories/form_page_component.rb
+++ b/app/components/territories/form_page_component.rb
@@ -24,7 +24,7 @@ class Territories::FormPageComponent < PageComponent
   end
 
   def territory_collection
-    Db::RegularTerritory.order(:name).pluck(:name, :id)
+    current_account.territories.regular.order(:name).pluck(:name, :id)
   end
 
   def area_collection

--- a/app/controllers/territories/territories_controller.rb
+++ b/app/controllers/territories/territories_controller.rb
@@ -6,7 +6,7 @@ class Territories::TerritoriesController < ApplicationController
 
   key :territory
 
-  scope { model_class.all.with_dependencies.search(params) }
+  scope { model_class.with_account(current_account).with_dependencies.search(params) }
 
   component_class_template 'Territories::%{type}PageComponent'
 

--- a/app/controllers/territories/territories_controller.rb
+++ b/app/controllers/territories/territories_controller.rb
@@ -2,6 +2,7 @@
 
 class Territories::TerritoriesController < ApplicationController
   include CrudController
+  include AccountAwareCrudController
 
   key :territory
 

--- a/app/models/db/account.rb
+++ b/app/models/db/account.rb
@@ -7,6 +7,8 @@ class Db::Account < ApplicationRecord
   has_many :publishers, dependent: :restrict_with_exception, class_name: 'Db::Publisher'
   has_many :field_service_groups, dependent: :restrict_with_exception,
                                   class_name: 'Db::FieldServiceGroup'
+  has_many :territories, dependent: :restrict_with_exception,
+                         class_name: 'Db::Territory'
 
   def to_s
     congregation_name

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -42,7 +42,8 @@ class Db::Territory < ApplicationRecord
 
   identifiable_by :name
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false, scope: :type }
+  validates :name, presence: true,
+                   uniqueness: { case_sensitive: false, scope: %i[account_id type] }
 
   mount_uploader :file, if Rails.env.production?
                           Territories::Uploaders::CloudinaryUploader

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -6,6 +6,7 @@ class Db::Territory < ApplicationRecord
 
   UNASSIGNED_TERRITORY_VALUE = 'none'
 
+  belongs_to :account, class_name: 'Db::Account'
   belongs_to :assignee, class_name: 'Publisher', optional: true
   belongs_to :territory, class_name: 'Territory', optional: true
   belongs_to :area, class_name: 'Db::TerritoryArea', optional: true

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -40,6 +40,8 @@ class Db::Territory < ApplicationRecord
       { territory: %i[area territory] }
     ])
   }
+  scope :with_account, ->(account) { where(account: account) }
+  scope :regular, -> { where(type: 'Db::RegularTerritory') }
 
   identifiable_by :name
 

--- a/app/services/apartment_building_territory_csv_import_service.rb
+++ b/app/services/apartment_building_territory_csv_import_service.rb
@@ -19,6 +19,10 @@ class ApartmentBuildingTerritoryCsvImportService
     apartments
   ].freeze
 
+  def initialize(account_id:)
+    @account_id = account_id
+  end
+
   def import_file(file)
     Db::ApartmentBuildingTerritory.transaction do
       CSV.parse(file, headers: true) do |row|
@@ -44,7 +48,7 @@ class ApartmentBuildingTerritoryCsvImportService
     letter_box_type = row.delete(:letter_box_type)
     intercom_type = row.delete(:intercom_type)
 
-    territory = Db::ApartmentBuildingTerritory.new(row)
+    territory = Db::ApartmentBuildingTerritory.new(row.merge(account_id: @account_id))
 
     if area
       territory.area = Db::TerritoryArea.find_or_create_by(name: area)

--- a/db/migrate/20221014113713_add_account_id_to_territories.rb
+++ b/db/migrate/20221014113713_add_account_id_to_territories.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddAccountIdToTerritories < ActiveRecord::Migration[6.1]
+  include AccountIdMigrationHelper
+
+  def up
+    add_account_ownership(:territories)
+
+    remove_index(:territories, %i[name type], unique: true)
+    add_index(:territories, %i[account_id name type], unique: true)
+  end
+
+  def down
+    remove_index(:territories, %i[account_id name type], unique: true)
+    add_index(:territories, %i[name type], unique: true)
+
+    remove_account_ownership(:territories)
+  end
+end

--- a/spec/models/db/account_spec.rb
+++ b/spec/models/db/account_spec.rb
@@ -7,4 +7,5 @@ RSpec.describe Db::Account, type: :model do
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:publishers).class_name('Db::Publisher') }
   it { is_expected.to have_many(:field_service_groups).class_name('Db::FieldServiceGroup') }
+  it { is_expected.to have_many(:territories).class_name('Db::Territory') }
 end

--- a/spec/models/db/field_service_group_spec.rb
+++ b/spec/models/db/field_service_group_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Db::FieldServiceGroup, type: :model do
-  let(:factories) { TestFactories.new }
+  subject(:group) { factories.field_service_groups.build }
+
   let(:publishers) { factories.publishers }
   let(:groups) { factories.field_service_groups }
   let(:publisher_group) { factories.publishers.create.group }

--- a/spec/models/db/territory_spec.rb
+++ b/spec/models/db/territory_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Db::Territory, type: :model do
 
       expect { territory.save! }.to change(described_class, :count).by(1)
     end
+
+    it 'accepts the same name and type if account is different' do
+      account = factories.accounts.create
+      factory.create(name: 'SomeName') # regular territory
+      territory = factory.build(name: 'Somename', account_id: account.id)
+
+      expect { territory.save! }.to change(described_class, :count).by(1)
+    end
   end
 
   it 'has an assignee' do

--- a/spec/models/db/territory_spec.rb
+++ b/spec/models/db/territory_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Db::Territory, type: :model do
       .dependent(:restrict_with_exception)
   }
 
+  it { is_expected.to belong_to(:account).class_name('Db::Account') }
+
   it 'persists' do
     expect { factory.create }.to change(described_class, :count).by(1)
   end
@@ -25,15 +27,15 @@ RSpec.describe Db::Territory, type: :model do
 
   describe '#name uniqueness' do
     it 'is scopped to type' do
-      factory.create(name: 'SomeName')
-      territory = factory.build
+      t1 = factory.create(name: 'SomeName')
+      territory = factory.build(account: t1.account)
 
       expect { territory.name = 'Somename' }.to change(territory, :valid?).from(true).to(false)
     end
 
     it 'accepts the same name if types are different' do
       factory.create(name: 'SomeName')
-      territory = described_class.new(name: 'Somename')
+      territory = factory.build(name: 'Somename')
 
       expect { territory.save! }.to change(described_class, :count).by(1)
     end
@@ -41,7 +43,7 @@ RSpec.describe Db::Territory, type: :model do
     it 'accepts the same name and type if account is different' do
       account = factories.accounts.create
       factory.create(name: 'SomeName') # regular territory
-      territory = factory.build(name: 'Somename', account_id: account.id)
+      territory = factory.build(name: 'Somename', account: account)
 
       expect { territory.save! }.to change(described_class, :count).by(1)
     end

--- a/spec/requests/congregation/publishers_request_spec.rb
+++ b/spec/requests/congregation/publishers_request_spec.rb
@@ -122,7 +122,9 @@ RSpec.describe Congregation::PublishersController, type: :request do
 
         perform_request
 
-        expected_component = form_component.new(key => model_class.new(invalid_attributes))
+        record = model_class.new(invalid_attributes)
+        record.account = current_account
+        expected_component = form_component.new(key => record)
         expect(renderer).to have_rendered_component(expected_component)
       end
     end
@@ -179,6 +181,8 @@ RSpec.describe Congregation::PublishersController, type: :request do
         perform_request
 
         record.attributes = invalid_attributes
+        record.account = current_account
+
         expected_component = form_component.new(key => record)
         expect(renderer).to have_rendered_component(expected_component)
       end

--- a/spec/requests/territories/apartment_building_territories_request_spec.rb
+++ b/spec/requests/territories/apartment_building_territories_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Territories::ApartmentBuildingTerritoriesController, type: :reque
 
   describe 'GET #index' do
     it 'returns http success' do
-      territory = factories.apartment_building_territories.create
+      territory = factories.apartment_building_territories.create(account: current_account)
       other = factories.phone_list_territories.create
 
       login_user(admin_user)

--- a/spec/requests/territories/apartment_building_territories_request_spec.rb
+++ b/spec/requests/territories/apartment_building_territories_request_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Territories::ApartmentBuildingTerritoriesController, type: :reque
 
         perform_request
 
-        new_territory = Db::ApartmentBuildingTerritory.new(name: '')
+        new_territory = Db::ApartmentBuildingTerritory.new(name: '', account_id: current_account.id)
         expected_component = Territories::FormPageComponent.new(territory: new_territory)
         expect(renderer).to have_rendered_component(expected_component)
       end
@@ -103,6 +103,7 @@ RSpec.describe Territories::ApartmentBuildingTerritoriesController, type: :reque
         perform_request
 
         territory.name = ''
+        territory.account_id = current_account.id
         expected_component = Territories::FormPageComponent.new(territory: territory)
         expect(renderer).to have_rendered_component(expected_component)
       end

--- a/spec/requests/territories/commercial_territories_request_spec.rb
+++ b/spec/requests/territories/commercial_territories_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Territories::CommercialTerritoriesController, type: :request do
 
   describe 'GET #index' do
     it 'returns http success' do
-      territory = factories.commercial_territories.create
+      territory = factories.commercial_territories.create(account: current_account)
       other = factories.territories.create
 
       get '/territories/commercial_territories'

--- a/spec/requests/territories/commercial_territories_request_spec.rb
+++ b/spec/requests/territories/commercial_territories_request_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Territories::CommercialTerritoriesController, type: :request do
 
         perform_request
 
-        new_territory = Db::CommercialTerritory.new(name: '')
+        new_territory = Db::CommercialTerritory.new(name: '', account: current_account)
         expected_component = Territories::FormPageComponent.new(territory: new_territory)
         expect(renderer).to have_rendered_component(expected_component)
       end
@@ -102,6 +102,7 @@ RSpec.describe Territories::CommercialTerritoriesController, type: :request do
         perform_request
 
         territory.name = ''
+        territory.account = current_account
         expected_component = Territories::FormPageComponent.new(territory: territory)
         expect(renderer).to have_rendered_component(expected_component)
       end

--- a/spec/requests/territories/phone_list_territories_request_spec.rb
+++ b/spec/requests/territories/phone_list_territories_request_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Territories::PhoneListTerritoriesController, type: :request do
 
     describe 'GET #index' do
       it 'returns http success' do
-        territory = factory.create
+        territory = factory.create(account: current_account)
         other = factories.territories.create
 
         get '/territories/phone_list_territories'

--- a/spec/requests/territories/phone_list_territories_request_spec.rb
+++ b/spec/requests/territories/phone_list_territories_request_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Territories::PhoneListTerritoriesController, type: :request do
 
           perform_request
 
-          new_territory = Db::PhoneListTerritory.new(name: '')
+          new_territory = Db::PhoneListTerritory.new(name: '', account_id: current_account.id)
           expected_component = Territories::FormPageComponent.new(territory: new_territory)
           expect(renderer).to have_rendered_component(expected_component)
         end
@@ -195,6 +195,7 @@ RSpec.describe Territories::PhoneListTerritoriesController, type: :request do
           perform_request
 
           territory.name = ''
+          territory.account = current_account
           expected_component = Territories::FormPageComponent.new(territory: territory)
           expect(renderer).to have_rendered_component(expected_component)
         end

--- a/spec/requests/territories/regular_territories_request_spec.rb
+++ b/spec/requests/territories/regular_territories_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Territories::RegularTerritoriesController, type: :request do
 
   describe 'GET #index' do
     it 'returns http success' do
-      territory = factories.territories.create
+      territory = factories.territories.create(account: current_account)
       other = factories.commercial_territories.create
 
       get '/territories/regular_territories'

--- a/spec/requests/territories/regular_territories_request_spec.rb
+++ b/spec/requests/territories/regular_territories_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Territories::RegularTerritoriesController, type: :request do
 
         perform_request
 
-        new_territory = Db::RegularTerritory.new(name: '')
+        new_territory = Db::RegularTerritory.new(name: '', account: current_account)
         expected_component = Territories::FormPageComponent.new(territory: new_territory)
         expect(renderer).to have_rendered_component(expected_component)
       end
@@ -122,6 +122,7 @@ RSpec.describe Territories::RegularTerritoriesController, type: :request do
         perform_request
 
         territory.name = ''
+        territory.account = current_account
         expected_component = Territories::FormPageComponent.new(territory: territory)
         expect(renderer).to have_rendered_component(expected_component)
       end

--- a/spec/services/apartment_building_territory_csv_import_service_spec.rb
+++ b/spec/services/apartment_building_territory_csv_import_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe ApartmentBuildingTerritoryCsvImportService, type: :service do
     contents = array.join
     file = StringIO.new(contents)
 
-    described_class.new.import_file(file)
+    described_class.new(account_id: factories.accounts.create.id).import_file(file)
 
     data
   end

--- a/spec/support/test_factories.rb
+++ b/spec/support/test_factories.rb
@@ -119,7 +119,7 @@ class TestFactories
           next
         end
 
-        added_values[id_key] = factories.send(model.to_s.pluralize).random_or_create.id
+        added_values[id_key] = factories.send(model.to_s.pluralize).create.id
       end
 
       added_values
@@ -236,7 +236,7 @@ class TestFactories
         initial_phone_number: 5_199_990_000 + seq,
         final_phone_number: 5_199_990_000 + seq,
         phone_provider: overrides[:phone_provider] || factories.phone_providers.random_or_create
-      }.merge(overrides)
+      }.merge(overrides).merge(associations([:account], overrides))
     end
   end
 
@@ -245,7 +245,7 @@ class TestFactories
       {
         name: "ApartmentBuilding-#{seq}",
         address: "Some address #{seq}"
-      }.merge(overrides)
+      }.merge(overrides).merge(associations([:account], overrides))
     end
   end
 
@@ -254,7 +254,7 @@ class TestFactories
       {
         name: "Territory-#{seq}",
         file: file_upload('sample_territory.jpg')
-      }.merge(overrides)
+      }.merge(overrides).merge(associations([:account], overrides))
     end
   end
 
@@ -262,7 +262,7 @@ class TestFactories
     def attributes(overrides = {})
       {
         name: "C-#{seq}"
-      }.merge(overrides)
+      }.merge(overrides).merge(associations([:account], overrides))
     end
   end
 


### PR DESCRIPTION
- Make account not optional to publishers and field service groups
- Add associations method to the test factories
- Add account_id to territories
- Add account relation to territories
