### PR TITLE
Add printable territory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'simple_form'
 gem 'kaminari'
 gem 'view_component', require: 'view_component/engine'
 gem 'webpacker', '~> 4.0'
+gem "rqrcode", "~> 2.0"
 
 group :development, :test do
   gem 'awesome_print'

--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,9 @@ gem 'sass-rails', '>= 6'
 gem 'simple_form'
 # gem 'turbolinks', '~> 5'
 gem 'kaminari'
+gem 'rqrcode', '~> 2.0'
 gem 'view_component', require: 'view_component/engine'
 gem 'webpacker', '~> 4.0'
-gem "rqrcode", "~> 2.0"
 
 group :development, :test do
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
     childprocess (3.0.0)
+    chunky_png (1.4.0)
     cloudinary (1.23.0)
       aws_cf_signer
       rest-client (>= 2.0.0)
@@ -307,6 +308,10 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.5)
+    rqrcode (2.1.2)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -461,6 +466,7 @@ DEPENDENCIES
   puma (~> 5.6)
   rails (~> 7.0)
   rails-controller-testing
+  rqrcode (~> 2.0)
   rspec-rails (= 4.0)
   rubocop (~> 1.8.1)
   rubocop-performance

--- a/app/components/concerns/territory_attributes_concern.rb
+++ b/app/components/concerns/territory_attributes_concern.rb
@@ -70,9 +70,17 @@ module TerritoryAttributesConcern
 
   def download_pdf_action
     if type == :phone_list
-      link_to(
+      return link_to(
         t('app.links.download_pdf'),
         urls.territory_download_pdf_path(territory),
+        class: 'btn'
+      )
+    end
+
+    if territory.kml.present? || territory.file.present?
+      link_to(
+        t('app.links.download_pdf'),
+        urls.territory_download_printable_path(territory),
         class: 'btn'
       )
     end

--- a/app/components/qr_code_component.html.erb
+++ b/app/components/qr_code_component.html.erb
@@ -1,0 +1,9 @@
+<%= 
+  code.as_svg(
+    color: "000",
+    shape_rendering: "crispEdges",
+    module_size: size,
+    standalone: true,
+    use_path: true
+  ).html_safe
+%>

--- a/app/components/qr_code_component.rb
+++ b/app/components/qr_code_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class QrCodeComponent < ApplicationComponent
+  attr_reader :size
+
+  def initialize(value)
+    @value = value
+    @size = 2
+  end
+
+  def with_size(size)
+    @size = size
+    self
+  end
+
+  def render?
+    @value.present?
+  end
+
+  def code
+    @code ||= RQRCode::QRCode.new(@value)
+  end
+end

--- a/app/components/territories/printable_territory_page_component.html.erb
+++ b/app/components/territories/printable_territory_page_component.html.erb
@@ -1,6 +1,9 @@
 <% if display_static_map? %>
   <%= image_tag(territory.static_map_url(scale: 4).to_s, height: 450) %>
 <% end %>
+<% if display_file? %>
+  <%= image_tag(territory.file.url, height: 450) %>
+<% end %>
 
 <h1> <%= territory.name %></h1>
 

--- a/app/components/territories/printable_territory_page_component.html.erb
+++ b/app/components/territories/printable_territory_page_component.html.erb
@@ -1,0 +1,9 @@
+<h1> <%= territory.name %></h1>
+
+<% if display_static_map? %>
+  <%= image_tag(territory.static_map_url(scale: 4).to_s) %>
+<% end %>
+
+<% if territory.notes.present? %>
+  <%= simple_format(territory.notes) %>
+<% end %>

--- a/app/components/territories/printable_territory_page_component.html.erb
+++ b/app/components/territories/printable_territory_page_component.html.erb
@@ -1,8 +1,8 @@
-<h1> <%= territory.name %></h1>
-
 <% if display_static_map? %>
-  <%= image_tag(territory.static_map_url(scale: 4).to_s) %>
+  <%= image_tag(territory.static_map_url(scale: 4).to_s, height: 450) %>
 <% end %>
+
+<h1> <%= territory.name %></h1>
 
 <% if territory.notes.present? %>
   <div><%= simple_format(territory.notes) %></div>

--- a/app/components/territories/printable_territory_page_component.html.erb
+++ b/app/components/territories/printable_territory_page_component.html.erb
@@ -5,5 +5,7 @@
 <% end %>
 
 <% if territory.notes.present? %>
-  <%= simple_format(territory.notes) %>
+  <div><%= simple_format(territory.notes) %></div>
 <% end %>
+
+<%= render QrCodeComponent.new(territory.google_map) %>

--- a/app/components/territories/printable_territory_page_component.rb
+++ b/app/components/territories/printable_territory_page_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Territories::PrintableTerritoryPageComponent < ApplicationComponent
+  has :territory
+
+  def display_static_map?
+    territory.has_static_map?
+  end
+end

--- a/app/components/territories/printable_territory_page_component.rb
+++ b/app/components/territories/printable_territory_page_component.rb
@@ -4,6 +4,10 @@ class Territories::PrintableTerritoryPageComponent < ApplicationComponent
   has :territory
 
   def display_static_map?
-    territory.has_static_map?
+    !display_file? && territory.has_static_map?
+  end
+
+  def display_file?
+    territory.file.present?
   end
 end

--- a/app/components/territories/show_page_component.html.erb
+++ b/app/components/territories/show_page_component.html.erb
@@ -59,3 +59,6 @@
 <%= render Territories::AssignmentsComponent.new(record: territory) %>
 
 <%= render GoogleMapComponent.new(url: territory.google_map) %>
+
+
+<%= render QrCodeComponent.new(territory.google_map) %>

--- a/app/controllers/territories/regular_territories_controller.rb
+++ b/app/controllers/territories/regular_territories_controller.rb
@@ -6,8 +6,6 @@ class Territories::RegularTerritoriesController < Territories::TerritoriesContro
   def printable
     territory = current_user.account.territories.regular.find(params[:regular_territory_id])
     @component = Territories::PrintableTerritoryPageComponent.new(territory: territory)
-    options = {}
-    # options[:disposition] = 'attachment'
-    export_pdf(territory.filename('pdf'), options)
+    export_pdf(territory.filename('pdf'), header: { right: territory.name })
   end
 end

--- a/app/controllers/territories/regular_territories_controller.rb
+++ b/app/controllers/territories/regular_territories_controller.rb
@@ -2,4 +2,12 @@
 
 class Territories::RegularTerritoriesController < Territories::TerritoriesController
   model_class Db::RegularTerritory
+
+  def printable
+    territory = current_user.account.territories.regular.find(params[:regular_territory_id])
+    @component = Territories::PrintableTerritoryPageComponent.new(territory: territory)
+    options = {}
+    # options[:disposition] = 'attachment'
+    export_pdf(territory.filename('pdf'), options)
+  end
 end

--- a/app/models/concerns/territory_uploader_concern.rb
+++ b/app/models/concerns/territory_uploader_concern.rb
@@ -5,6 +5,10 @@ module TerritoryUploaderConcern
 
   module ClassMethods
     def file_uploader
+      if Rails.env.test?
+        return Territories::Uploaders::LocalUploader
+      end
+
       if Rails.env.production?
         return Territories::Uploaders::CloudinaryUploader
       end

--- a/app/models/db/phone_list_territory.rb
+++ b/app/models/db/phone_list_territory.rb
@@ -26,8 +26,4 @@ class Db::PhoneListTerritory < Db::Territory
       phone_provider_id
     ]
   end
-
-  def filename(extension = nil)
-    [name, extension].compact.join('.')
-  end
 end

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -175,7 +175,7 @@ class Db::Territory < ApplicationRecord
 
   def static_map_url(params = {})
     if has_static_map?
-      params = { size: '580x380', zoom: 16, scale: 1 }
+      params = { size: '2048x2048', zoom: 17, scale: 4 }
 
       GoogleMaps::StaticMapService
         .new(api_key: account.google_api_key_for_static_maps)

--- a/app/models/db/territory.rb
+++ b/app/models/db/territory.rb
@@ -173,14 +173,14 @@ class Db::Territory < ApplicationRecord
     end
   end
 
-  def static_map_url
+  def static_map_url(params = {})
     if has_static_map?
       params = { size: '580x380', zoom: 16, scale: 1 }
 
       GoogleMaps::StaticMapService
         .new(api_key: account.google_api_key_for_static_maps)
         .url_from_kml(kml)
-        .with_added_query_params(params.merge(custom_map_params))
+        .with_added_query_params(params.merge(custom_map_params).merge(params))
     end
   end
 
@@ -230,6 +230,10 @@ class Db::Territory < ApplicationRecord
 
   def static_map_center
     read_config(:static_map_center)
+  end
+
+  def filename(extension = nil)
+    [name, extension].compact.join('.')
   end
 
   private

--- a/app/models/routes.rb
+++ b/app/models/routes.rb
@@ -32,6 +32,10 @@ class Routes
     @helpers.pdf_territories_phone_list_territory_path(territory, params)
   end
 
+  def territory_download_printable_path(territory, params = {})
+    @helpers.territories_regular_territory_printable_path(territory, params)
+  end
+
   def new_territory_assignment_path(territory)
     @helpers.new_territories_territory_assignment_path(territory)
   end

--- a/app/views/territories/regular_territories/printable.pdf.erb
+++ b/app/views/territories/regular_territories/printable.pdf.erb
@@ -1,0 +1,1 @@
+<%= render @component %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,9 @@ Rails.application.routes.draw do
     resources :territories, only: [:show] do
       resources :assignments
     end
-    resources :regular_territories
+    resources :regular_territories do
+      get :printable, defaults: { format: :pdf }
+    end
     resources :phone_list_territories do
       member do
         get :xls

--- a/spec/components/qr_code_component_spec.rb
+++ b/spec/components/qr_code_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QrCodeComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/components/qr_code_component_spec.rb
+++ b/spec/components/qr_code_component_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe QrCodeComponent, type: :component do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/components/territories/printable_territory_page_component_spec.rb
+++ b/spec/components/territories/printable_territory_page_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Territories::PrintableTerritoryPageComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end


### PR DESCRIPTION
 Close #306

- Prints basic map when it has KML map
- Install ruby QR code gem
- Add page for downloading the territory printable version
- Add link to download printable version of territory
- Appease rubocop
- Improve layout of printable territory
- Add ability to print cloudinary map
