### PR TITLE
Revert "Bump omniauth from 1.9.2 to 2.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'activeadmin'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'caxlsx'
 gem 'dotenv-rails'
-gem 'omniauth', '~> 2.0.0'
+gem 'omniauth', '~> 1.9.2'
 gem 'omniauth-google-oauth2'
 gem 'pg', '~> 1.2'
 gem 'puma', '~> 5.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,17 +235,16 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     object_comparator (0.1.3)
-    omniauth (2.0.0)
+    omniauth (1.9.2)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-      rack-protection
-    omniauth-google-oauth2 (1.0.1)
+    omniauth-google-oauth2 (0.8.2)
       jwt (>= 2.0)
       oauth2 (~> 1.1)
-      omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.7.1)
-    omniauth-oauth2 (1.7.3)
-      oauth2 (>= 1.4, < 3)
+      omniauth (~> 1.1)
+      omniauth-oauth2 (>= 1.6)
+    omniauth-oauth2 (1.7.1)
+      oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -255,9 +254,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.6.2)
-    rack-protection (3.0.5)
-      rack
+    rack (2.2.5)
     rack-proxy (0.7.0)
       rack
     rack-test (2.0.2)
@@ -463,7 +460,7 @@ DEPENDENCIES
   koine-rest_client
   listen (~> 3.4)
   object_comparator
-  omniauth (~> 2.0.0)
+  omniauth (~> 1.9.2)
   omniauth-google-oauth2
   pg (~> 1.2)
   puma (~> 5.6)


### PR DESCRIPTION
This reverts commit 67fa51115965eaa4d5d3a43f33b4a2b59bd7a68c.

Not ready yet for a `POST` login. See https://github.com/omniauth/omniauth/releases/tag/v2.0.0
